### PR TITLE
add required libraries

### DIFF
--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -26,12 +26,17 @@ virtualenv env
 pip install --no-cache-dir -r requirements.txt
 
 pushd /tmp
-yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre
+yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre libprelude gnutls libtasn1 lib64nettle nettle
 rpm2cpio pcre*.rpm | cpio -idmv
 rpm2cpio json-c*.rpm | cpio -idmv
 rpm2cpio clamav-0*.rpm | cpio -idmv
 rpm2cpio clamav-lib*.rpm | cpio -idmv
 rpm2cpio clamav-update*.rpm | cpio -idmv
+rpm2cpio gnutls* | cpio -idmv
+rpm2cpio nettle* | cpio -idmv
+rpm2cpio lib* | cpio -idmv
+rpm2cpio *.rpm | cpio -idmv
+rpm2cpio libtasn1* | cpio -idmv
 popd
 mkdir -p bin
 cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* bin/.


### PR DESCRIPTION
[PROD-8735](https://bonfirehub.atlassian.net/browse/PROD-8735)

We are seeing errors for av scanning that are related to libraries not being loaded properly:

`./bin/clamscan: error while loading shared libraries: libpcre.so.1: cannot open shared object file: No such file or directory`

I saw that this issue has been fixed in https://github.com/bluesentry/bucket-antivirus-function/issues/125

This PR adds that fix to this repo